### PR TITLE
Add json restrictions on playbook run requests

### DIFF
--- a/runner_service/controllers/utils.py
+++ b/runner_service/controllers/utils.py
@@ -35,10 +35,15 @@ def log_request(logger):
         def wrapper(*args, **kwargs):
             """ Look at the request, and log the details """
             # logger.info("{}".format(request.url))
-            logger.info("{} - {} {}, parms={}".format(request.remote_addr,
-                                                      request.method,
-                                                      request.path,
-                                                      request.values.to_dict()))
+            logger.debug("request received, type :{}".format(request.content_type))
+            if request.content_type == 'application/json':
+                sfx = ", parms={}".format(request.get_json())
+            else:
+                sfx = ''
+            logger.info("{} - {} {}{}".format(request.remote_addr,
+                                              request.method,
+                                              request.path,
+                                              sfx))
             return f(*args, **kwargs)
         return wrapper
 

--- a/runner_service/services/playbook.py
+++ b/runner_service/services/playbook.py
@@ -116,5 +116,7 @@ def watcher(pb_thread, pb_runner):
     """
 
     pb_thread.join()
-    logger.info("Play {} finished, status={}".format(pb_runner.config.ident,
-                                                     pb_runner.status))
+    logger.info("Playbook {}, UUID={} ended, "
+                "status={}".format(pb_runner.config.playbook,
+                                   pb_runner.config.ident,
+                                   pb_runner.status))


### PR DESCRIPTION
Ideally we should check content-type is appropriate on all requests. This is the first commit where this is enforced on a playbook start request. In addition, some cosmetic/doc changes have been made to logging and the class comments (seen in the api doc page)