### PR TITLE
Use the finished_callback at the end of a run

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ versions of packages like flask that may not work correctly.
 
 ### Package Dependencies
 - pyOpenSSL  (python2-pyOpenSSL, python3-pyOpenSSL on Fedora, CentOS pyOpenSSL)
+- ansible_runner 1.0.5 or above
 
 ## Installation
 Try before you buy...simply unzip the archive and run :)


### PR DESCRIPTION
ansible_runner 1.0.5 added a callback invoked at
the end of a playbook run. This update uses this
callback instead of watching the playbook
execution thread.

Closes: https://github.com/pcuzner/ansible-runner-service/issues/12

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>