### PR TITLE
Testes Travis CI and included Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ build
 .idea
 venv
 .tox
+# Virtual env folders
+bin
+include
+lib*
+pip-self*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.6"
 
+cache: pip
+
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ install:
 
 script:
   - flake8 --ignore=E501 ansible-runner-service.py runner-service/
+  - python -m unittest tests/test_*.py

--- a/runner_service/__init__.py
+++ b/runner_service/__init__.py
@@ -6,6 +6,9 @@ from .inventory import (AnsibleInventory,           # noqa: F401
                         InventoryWriteError,
                         InventoryGroupExists,
                         InventoryHostMissing,
-                        InventoryGroupMissing)
+                        InventoryGroupMissing,
+                        InventoryreadError,
+                        InventoryCorruptError,
+                        InventoryOperationNotAllowed)
 
 __version__ = 0.7

--- a/runner_service/inventory.py
+++ b/runner_service/inventory.py
@@ -42,6 +42,14 @@ class InventoryWriteError(Exception):
     pass
 
 
+class InventoryreadError(Exception):
+    pass
+
+
+class InventoryCorruptError(Exception):
+    pass
+
+
 def no_group(func):
     def func_wrapper(*args):
         obj, group = args
@@ -91,37 +99,52 @@ class AnsibleInventory(object):
 
         if not os.path.exists(self.filename):
             try:
-                with open(self.filename, 'w') as inv:
+                # Using Python 3 exclusive creation
+                with open(self.filename, 'x') as inv:                    
                     inv.write(yaml.dump(AnsibleInventory.inventory_seed,
-                                        default_flow_style=False))
+                                            default_flow_style=False))
+            except FileExistsError:
+                logger.info("Inventory file '{}' already created".format(self.filename))
             except IOError:
                 raise InventoryWriteError("Unable to create the seed inventory"
                                           " file at {}".format(self.filename))
-
-        if self.exclusive_lock:
-
-            try:
-                self.fd = open(self.filename, 'r+')
-                self.lock()
-            except (BlockingIOError, OSError):
-                # Can't obtain an exclusive_lock
-                self.fd.close()
-                return
+            
+        try:    
+            if self.exclusive_lock:
+                try:
+                    self.fd = open(self.filename, 'r+')
+                    self.lock()
+                except (BlockingIOError, OSError):
+                    # Can't obtain an exclusive_lock
+                    self.fd.close()
+                    return
+                else:
+                    raw = self.fd.read().strip()
             else:
-                raw = self.fd.read().strip()
-        else:
-            raw = fread(self.filename)
+                raw = fread(self.filename)
+        except Exception as ex:
+            raise InventoryreadError("Unable to read the inventory"
+                                     " file at {}, error: {}".format(self.filename, ex))
 
         if not raw:
-            self.inventory = None
+            # If the inventory is empty for some extrange reason
+            self.inventory = AnsibleInventory.inventory_seed
         else:
-            # TODO what happens with invalid yaml?
-            self.inventory = yaml.safe_load(raw)
-
+            # invalid yaml management
+            try:
+                self.inventory = yaml.safe_load(raw)
+            except yaml.YAMLError as ex:
+                raise InventoryCorruptError("Unable to understand the inventory"
+                                            " yaml file at {}, error: {}".format(self.filename, ex))
+        
     def _dump(self):
         return yaml.dump(self.inventory, default_flow_style=False)
 
     def save(self):
+        # Get the only when fd when we are going to save
+        self.fd = open(self.filename, 'w')
+        if self.exclusive_lock:
+            self.lock()
         self.fd.seek(0)
         self.fd.write(self._dump())
         self.fd.truncate()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -33,20 +33,20 @@ class TestInventory(unittest.TestCase):
         self.assertTrue(os.path.exists(self.filename))
 
     def test_02_check_empty(self):
-        self.assertEqual(self.inventory.sections, [])
-
+        self.assertEqual(self.inventory.groups, [])
+        self.assertEqual(self.inventory.hosts, [])
+        
     def test_03_group_missing(self):
         with self.assertRaises(InventoryGroupMissing):
             self.inventory.group_remove('dodgy')
 
     def test_04_group_add(self):
         self.inventory.group_add('newgroup')
-        # self.inventory.write()
-        self.assertIn('newgroup', self.inventory.sections)
-
+        self.assertIn('newgroup', self.inventory.groups)
+    
     def test_05_group_remove(self):
         self.inventory.group_remove('newgroup')
-        self.assertNotIn('newgroup', self.inventory.sections)
+        self.assertNotIn('newgroup', self.inventory.groups)
 
     def test_06_host_add_invalid(self):
         with self.assertRaises(InventoryGroupMissing):
@@ -54,8 +54,8 @@ class TestInventory(unittest.TestCase):
 
     def test_07_group_add(self):
         self.inventory.group_add('mygroup')
-        self.assertIn('mygroup', self.inventory.sections)
-
+        self.assertIn('mygroup', self.inventory.groups)
+    
     def test_08_host_add(self):
         self.inventory.host_add('mygroup', 'myhost')
         self.assertIn('myhost', self.inventory.group_show('mygroup'))
@@ -67,22 +67,24 @@ class TestInventory(unittest.TestCase):
     def test_10_save(self):
         self.inventory.host_add('mygroup', 'host-1')
         self.inventory.host_add('mygroup', 'host-2')
-        self.inventory.write()
+        self.inventory.save()
         with open(self.filename) as i:
             data = i.readlines()
 
-        # should only be 7 records in the file
-        self.assertEqual(len(data), 7)
+        # should only be 6 records in the file
+        #['all:\n', '  children:\n', '    mygroup:\n', '
+        #  hosts:\n', '        host-1:\n', '        host-2:\n']
+        self.assertEqual(len(data), 6)
 
     def test_11_remove_nonempty(self):
         self.inventory.group_remove('mygroup')
-        self.assertNotIn('mygroup', self.inventory.sections)
+        self.assertNotIn('mygroup', self.inventory.groups)
+    
 
     @classmethod
     def tearDownClass(cls):
         # Remove the inventory file we were using
         os.unlink(TestInventory.filename)
-
 
 def main():
     unittest.main(verbosity=2)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -13,9 +13,18 @@ logger.setLevel(logging.DEBUG)
 # runner_service needs to be installed
 #
 
+INV_FILENAME = os.path.expanduser('~/inventory')
+
+def delete_file(filename):
+    """ Delete the file passed as parameter if it exists
+    """
+
+    if os.path.isfile(filename):
+        os.remove(filename)
+
 
 class TestInventory(unittest.TestCase):
-    # setup the inventory file
+    # setup the inventory file (with/without exclusive access)
     # add a group
     # remove a group that doesn't exist
     # remove a group that does
@@ -26,65 +35,143 @@ class TestInventory(unittest.TestCase):
     # add multiple hosts to a group
     #   then remove the group
     # shutdown - delete the inventory file
-    filename = os.path.expanduser('~/inventory')
-    inventory = AnsibleInventory(filename)
+    
+
+    def setUp(self):
+        """ Start with a clean environment in each test
+        """
+
+        delete_file(INV_FILENAME)
+
+    def test_01_exclusive_inventory_created(self):
+        """Setup the inventory file with exclusive access)
+        """
+        
+        inventory = AnsibleInventory(INV_FILENAME, True)
+      
+        self.assertTrue(os.path.exists(INV_FILENAME))
+
+
+        # this should raise an error ... 
+        inventory2 = AnsibleInventory(INV_FILENAME, True)
 
     def test_01_inventory_created(self):
-        self.assertTrue(os.path.exists(self.filename))
+        """Setup the inventory file without exclusive access)
+        """
+        
+        inventory = AnsibleInventory(INV_FILENAME)
+      
+        self.assertTrue(os.path.exists(INV_FILENAME))
+
+        # This should work
+        inventory2 = AnsibleInventory(INV_FILENAME)
 
     def test_02_check_empty(self):
-        self.assertEqual(self.inventory.groups, [])
-        self.assertEqual(self.inventory.hosts, [])
+        """Check inventory is empty
+        """
         
+        inventory = AnsibleInventory(INV_FILENAME, True)
+        
+        self.assertEqual(inventory.groups, [])
+        self.assertEqual(inventory.hosts, [])
+    
     def test_03_group_missing(self):
+        """Check error raised when a group does not exist
+        """
+
+        inventory = AnsibleInventory(INV_FILENAME, True)
         with self.assertRaises(InventoryGroupMissing):
-            self.inventory.group_remove('dodgy')
+            inventory.group_remove('dodgy')
 
     def test_04_group_add(self):
-        self.inventory.group_add('newgroup')
-        self.assertIn('newgroup', self.inventory.groups)
-    
+        """Check group addition
+        """
+        
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)
+        inventory.group_add('newgroup')
+        self.assertIn('newgroup', inventory.groups)
+
+
     def test_05_group_remove(self):
-        self.inventory.group_remove('newgroup')
-        self.assertNotIn('newgroup', self.inventory.groups)
+        """Check remove a group that exists
+        """
+
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)
+        inventory.group_add('newgroup')
+        self.assertIn('newgroup', inventory.groups)
+
+        # two write operations not supported.. 
+        # Needed another AnsibleInventary Object
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)  
+        inventory.group_remove('newgroup')
+        self.assertNotIn('newgroup', inventory.groups)
 
     def test_06_host_add_invalid(self):
-        with self.assertRaises(InventoryGroupMissing):
-            self.inventory.host_add('mygroup', 'myhost')
+        """add a host to a non-existent group
+        """
 
-    def test_07_group_add(self):
-        self.inventory.group_add('mygroup')
-        self.assertIn('mygroup', self.inventory.groups)
-    
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)
+        with self.assertRaises(InventoryGroupMissing):
+            inventory.host_add('mygroup', 'myhost')
+
     def test_08_host_add(self):
-        self.inventory.host_add('mygroup', 'myhost')
-        self.assertIn('myhost', self.inventory.group_show('mygroup'))
+        """add a host to an existent group
+        """        
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)
+        inventory.group_add('mygroup')
+        self.assertIn('mygroup', inventory.groups)
+        
+        # two write operations not supported.. 
+        # Needed another AnsibleInventary Object 
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)       
+        inventory.host_add('mygroup', 'myhost')
+        self.assertIn('myhost', inventory.group_show('mygroup'))
+
 
     def test_09_host_remove(self):
-        self.inventory.host_remove('mygroup', 'myhost')
-        self.assertNotIn('myhost', self.inventory.group_show('mygroup'))
+        """remove a host from an existent group
+        """ 
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)
+        inventory.group_add('mygroup')
+        self.assertIn('mygroup', inventory.groups)
+        
+        # two write operations not supported.. 
+        # Needed another AnsibleInventary Object 
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)       
+        inventory.host_add('mygroup', 'myhost')
+        self.assertIn('myhost', inventory.group_show('mygroup'))        
+        
+        # two write operations not supported.. 
+        # Needed another AnsibleInventary Object
+        inventory = AnsibleInventory(INV_FILENAME, excl=True) 
+        inventory.host_remove('mygroup', 'myhost')
+        self.assertNotIn('myhost', inventory.group_show('mygroup'))
 
-    def test_10_save(self):
-        self.inventory.host_add('mygroup', 'host-1')
-        self.inventory.host_add('mygroup', 'host-2')
-        self.inventory.save()
-        with open(self.filename) as i:
-            data = i.readlines()
-
-        # should only be 6 records in the file
-        #['all:\n', '  children:\n', '    mygroup:\n', '
-        #  hosts:\n', '        host-1:\n', '        host-2:\n']
-        self.assertEqual(len(data), 6)
 
     def test_11_remove_nonempty(self):
-        self.inventory.group_remove('mygroup')
-        self.assertNotIn('mygroup', self.inventory.groups)
-    
+        """remove a group with hosts
+        """ 
+
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)
+        inventory.group_add('mygroup')
+        self.assertIn('mygroup', inventory.groups)
+        
+        # two write operations not supported.. 
+        # Needed another AnsibleInventary Object 
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)       
+        inventory.host_add('mygroup', 'myhost')
+        self.assertIn('myhost', inventory.group_show('mygroup'))        
+
+        # two write operations not supported.. 
+        # Needed another AnsibleInventary Object 
+        inventory = AnsibleInventory(INV_FILENAME, excl=True)         
+        inventory.group_remove('mygroup')
+        self.assertNotIn('mygroup', inventory.groups)
 
     @classmethod
     def tearDownClass(cls):
         # Remove the inventory file we were using
-        os.unlink(TestInventory.filename)
+        os.unlink(INV_FILENAME)
 
 def main():
     unittest.main(verbosity=2)


### PR DESCRIPTION
I have improve the CI execution duration caching the dependencies of pip packages.

Executing the unit tests i have seen that when the inventory file is created the AnsibleInventary" fd attribute wasn't properly initialized. 
I have made several changes, although i think that this can be improved ( probably we should use a database to keep the inventory and avoid concurrency problems, this will be even more healthy if we are running the tool using several instances in several servers)
Minor changes in the unit test ( basically removed  obsolete methods)

I have include the execution of the unit test in the CI Travis config file.

And i have build succesfully with Travis:
https://travis-ci.org/jmolmo/ansible-runner-service/builds/427189758
