### PR TITLE
Adding unit test coverage using codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ install:
 script:
   - flake8 --ignore=E501 ansible-runner-service.py runner-service/
   - python -m unittest tests/test_*.py
+
+after_success:
+- coverage run --source=runner_service -m unittest tests/test_*.py
+- bash < (curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ branches:
 install:
   - pip install -r requirements.txt
   - python setup.py -q install
+  - pip install coverage
 
 script:
   - flake8 --ignore=E501 ansible-runner-service.py runner-service/
@@ -18,4 +19,5 @@ script:
 
 after_success:
 - coverage run --source=runner_service -m unittest tests/test_*.py
+- coverage report
 - bash < (curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ install:
   - pip install -r requirements.txt
   - python setup.py -q install
   - pip install coverage
+  - pip install codecov
 
 script:
   - flake8 --ignore=E501 ansible-runner-service.py runner-service/
   - python -m unittest tests/test_*.py
+  - coverage run --source=runner_service -m unittest tests/test_*.py
 
 after_success:
-- coverage run --source=runner_service -m unittest tests/test_*.py
-- coverage report
-- bash < (curl -s https://codecov.io/bash)
+- codecov


### PR DESCRIPTION
Once setup the tool we will have a nice report in each PR :+1: 
- you can see an example in my repo:
https://github.com/jmolmo/ansible-runner-service/pull/1

- Apart of that, is also possible to review the code coverage with the Codecov dashboard. 
https://codecov.io/gh/jmolmo/ansible-runner-service
Note: play with the sunburst graphic!!... when you reach the file "level" , if you clik in the name of the file you can see clearly all the lines covered.
