### PR TITLE
Change inventory file locking and add more host API endpoints

### DIFF
--- a/runner_service/inventory.py
+++ b/runner_service/inventory.py
@@ -259,7 +259,7 @@ class AnsibleInventory(object):
                                                                       group))
             else:
                 del self.inventory['all']['children'][group]['hosts'][host]
-                logger.info("Host ''{}' removed from inventory group "
+                logger.info("Host '{}' removed from inventory group "
                             "'{}'".format(host, group))
                 if not self.inventory['all']['children'][group]['hosts']:
                     self.inventory['all']['children'][group]['hosts'] = None

--- a/runner_service/services/groups.py
+++ b/runner_service/services/groups.py
@@ -16,7 +16,7 @@ def add_group(group_name):
         try:
             inventory.group_add(group_name)
         except InventoryGroupExists:
-            r.status, r.msg = 'INVALID', 'Group already exists'
+            r.status, r.msg = 'OK', 'Group already exists'
         else:
             r.status, r.msg = 'OK', 'Group {} added'.format(group_name)
 

--- a/runner_service/services/hosts.py
+++ b/runner_service/services/hosts.py
@@ -12,7 +12,8 @@ def add_host(host_name, group_name):
     r = APIResponse()
     inventory = AnsibleInventory(excl=True)
     if not inventory.loaded:
-        r.status, r.msg = "LOCKED", "Unable to lock the inventory file, try later"
+        r.status, r.msg = "LOCKED", \
+                          "Unable to lock the inventory file, try later"
         return r
 
     if group_name not in inventory.groups:
@@ -24,7 +25,8 @@ def add_host(host_name, group_name):
     group_members = inventory.group_show(group_name)
     if host_name in group_members:
         # host already in that group!
-        r.status, r.msg = "OK", "Host already in the group {}".format(group_name)
+        r.status, r.msg = "OK", \
+                          "Host already in the group {}".format(group_name)
         inventory.unlock()
         return r
 

--- a/runner_service/services/hosts.py
+++ b/runner_service/services/hosts.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 def add_host(host_name, group_name):
     r = APIResponse()
+    r.data = {"hostname": host_name}
     inventory = AnsibleInventory(excl=True)
     if not inventory.loaded:
         r.status, r.msg = "LOCKED", \
@@ -57,6 +58,7 @@ def add_host(host_name, group_name):
 
     inventory.host_add(group_name, host_name)
     r.status = "OK"
+    r.msg = "{} added".format(host_name)
 
     return r
 

--- a/tests/test_api_inventory.py
+++ b/tests/test_api_inventory.py
@@ -304,8 +304,10 @@ class TestInventory(APITestCase):
         inv_data = yaml.safe_load(fread(inv_filename))
         groups = inv_data['all']['children'].keys()
         for group in groups:
-            self.assertNotIn("localhost",
-                             inv_data['all']['children'][group]['hosts'].keys()) # noqa
+            hosts_in_group = inv_data['all']['children'][group]['hosts']
+            if isinstance(hosts_in_group, dict):
+                self.assertNotIn("localhost",
+                                 hosts_in_group.keys())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Inventory file locking now has 5 retries, to avoid just failing the request to the caller. In additional, host endpoints in the API have been updated to allow a complete single call removal of a host, and a single call addition of a host across multiple ansible groups.