### PR TITLE
Increase SSL key strength

### DIFF
--- a/runner_service/utils.py
+++ b/runner_service/utils.py
@@ -50,7 +50,7 @@ def create_self_signed_cert(cert_dir, cert_pfx):
 
         # create a key pair
         k = crypto.PKey()
-        k.generate_key(crypto.TYPE_RSA, 1024)
+        k.generate_key(crypto.TYPE_RSA, 2048)
 
         # create a self-signed cert
         cert = crypto.X509()


### PR DESCRIPTION
Key was using 1024, but this fails on RHEL8
as being too weak.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>